### PR TITLE
Error callback support

### DIFF
--- a/src/vast-vmap.js
+++ b/src/vast-vmap.js
@@ -418,11 +418,11 @@ function VASTAds(root, onAdsAvailable, onError, parentAd) {
 
   var onAdError = function () {
     that.onReceivedErrorCounter++;
-    if (that.onReceivedErrorCounter == adElements.length) {
+    if (that.onReceivedErrorCounter === adElements.length) {
       onError();
       return;
     }
-  }
+  };
 
   for (var i = 0; i < adElements.length; i++) {
     var ad = new VASTAd(this, adElements.item(i), parentAd || null);

--- a/src/vast-vmap.js
+++ b/src/vast-vmap.js
@@ -418,9 +418,9 @@ function VASTAds(root, onAdsAvailable, onError, parentAd) {
   var onAdError = function () {
     onReceivedErrorCounter++;
     if (that.onAdsError) {
-+      var oae = that.onAdsError;
-+      that.onAdsError = null;
-+      oae.call();
+       var oae = that.onAdsError;
+       that.onAdsError = null;
+       oae.call();
 +    }
   }
 

--- a/src/vast-vmap.js
+++ b/src/vast-vmap.js
@@ -392,8 +392,6 @@ VMAP.prototype.onBreakEnd = function(break_index) {
   this.breaks[break_index].tracking.track("breakEnd");
 };
 
-var onReceivedErrorCounter = 0;
-
 /**
  * Represents one VAST response which might contain multiple ads
  *
@@ -413,15 +411,17 @@ function VASTAds(root, onAdsAvailable, onError, parentAd) {
   this.ads = [];
   this.onAdsAvailable = onAdsAvailable;
   this.onAdsError = onError;
+  this.onReceivedErrorCounter = 0;
   var adElements = root.getElementsByTagNameNS(root.namespaceURI, 'Ad');
 
-  var onAdError = function () {
-    onReceivedErrorCounter++;
-  }
+  var that = this;
 
-  if (onReceivedErrorCounter == adElements.length) {
-    onError();
-    return;
+  var onAdError = function () {
+    that.onReceivedErrorCounter++;
+    if (that.onReceivedErrorCounter == adElements.length) {
+      onError();
+      return;
+    }
   }
 
   for (var i = 0; i < adElements.length; i++) {
@@ -441,7 +441,6 @@ function VASTAds(root, onAdsAvailable, onError, parentAd) {
         oaf.call(this, this);
       }
     } else {
-      var that = this;
       var wrapper = adElements.item(i).getElementsByTagName('Wrapper').item(0);
       var uri = wrapper.getElementsByTagName('VASTAdTagURI');
       if (uri.length === 0) {

--- a/src/vast-vmap.js
+++ b/src/vast-vmap.js
@@ -417,15 +417,10 @@ function VASTAds(root, onAdsAvailable, onError, parentAd) {
 
   var onAdError = function () {
     onReceivedErrorCounter++;
-    if (that.onAdsError) {
-       var oae = that.onAdsError;
-       that.onAdsError = null;
-       oae.call();
-+    }
   }
 
   if (onReceivedErrorCounter == adElements.length) {
-    onAdError();
+    onError();
     return;
   }
 

--- a/test/assets/vast_ad_redirect.xml
+++ b/test/assets/vast_ad_redirect.xml
@@ -1,0 +1,10 @@
+
+<?xml version="1.0" encoding="UTF-8"?>
+<VAST xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vast.xsd" version="3.0">
+ <Ad id="101124619">
+  <Wrapper>
+   <AdSystem>GDFP</AdSystem>
+   <VASTAdTagURI><![CDATA[./vast_wrapper_no_ads.xml]]></VASTAdTagURI>
+  </Wrapper>
+ </Ad>
+</VAST>

--- a/test/assets/vast_wrapper_no_ads.xml
+++ b/test/assets/vast_wrapper_no_ads.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VAST version="2.0">
+    <Ad id="602833">
+      <Wrapper>
+      </Wrapper>
+    </Ad>
+    <Ad id="602834">
+      <Wrapper>
+      </Wrapper>
+    </Ad>
+</VAST>

--- a/test/test-ad-redirect.js
+++ b/test/test-ad-redirect.js
@@ -1,0 +1,23 @@
+abuster.testCase("Empty wrappers", {
+  errorCounter: 0,
+
+  prepare: function(done) {
+    var that = this;
+    queryVAST("./test/assets/vast_ad_redirect.xml", function(ads) {
+      that.vast = ads;
+      done();
+    }, function() {
+      that.errorCounter++;
+    });
+  },
+
+  setUp: function() {
+    this.ad = this.vast.getAd();
+    this.ad.sentImpression = false;
+  },
+
+  "called onError once": function() {
+    assert.equals(this.errorCounter, 1);
+  },
+
+})

--- a/test/test-wrapper-no-ads.js
+++ b/test/test-wrapper-no-ads.js
@@ -1,0 +1,23 @@
+buster.testCase("Empty wrappers", {
+  errorCounter: 0,
+
+  prepare: function(done) {
+    var that = this;
+    queryVAST("./test/assets/vast_wrapper_no_ads.xml", function(ads) {
+      that.vast = ads;
+      done();
+    }, function() {
+      that.errorCounter++;
+    });
+  },
+
+  setUp: function() {
+    this.ad = this.vast.getAd();
+    this.ad.sentImpression = false;
+  },
+
+  "called onError once": function() {
+    assert.equals(this.errorCounter, 1);
+  },
+
+})


### PR DESCRIPTION
Added support for an `onError` callback to be passed into `queryVAST` in addition to the success callback.