### PR TITLE
Support aborting further VAST queries after unwrapping `X` wrappers.

### DIFF
--- a/src/vast-vmap.js
+++ b/src/vast-vmap.js
@@ -109,6 +109,10 @@ function fetchXML(url, identifier, onSuccess, onFailure) {
 function queryVAST(endpoint, onFetched, onError, parentAd) {
   var e = "Reached abort limit of (" + VAST_VMAP_XHROptions.defaultVASTAbortLimit + ") wrappers.";
   /**
+   * Handle the case where there's an error, but no onError provided.
+   */
+  onError = onError || function () {};
+  /**
    * Abort and call onError() immediately in the following conditions
    * 1.  There is no parentAd (this would be the root ad) AND the VAST_VMAP_XHROptions.defaultVASTAbortLimit is 0
    * 2.  There is a parentAd (this is not the root ad) AND parentAd.abortLimit is 0

--- a/test/assets/vast_wrapper_linear_2.xml
+++ b/test/assets/vast_wrapper_linear_2.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VAST version="2.0">
+  <Ad id="602833">
+  <Wrapper>
+    <AdSystem>Acudeo Compatible</AdSystem>
+    <VASTAdTagURI>./test/assets/vast_wrapper_linear_1.xml</VASTAdTagURI>
+    <Error>/wrapper/error</Error>
+    <Impression>/wrapper/impression</Impression>
+  <Creatives>
+    <Creative AdID="602833">
+      <Linear>
+        <TrackingEvents>
+          <Tracking event="creativeView">/wrapper/creativeView</Tracking>
+          <Tracking event="start">/wrapper/start</Tracking>
+          <Tracking event="midpoint">/wrapper/midpoint</Tracking>
+          <Tracking event="firstQuartile">/wrapper/firstQuartile</Tracking>
+          <Tracking event="thirdQuartile">/wrapper/thirdQuartile</Tracking>
+          <Tracking event="complete">/wrapper/complete</Tracking>
+          <Tracking event="mute">/wrapper/mute</Tracking>
+          <Tracking event="unmute">/wrapper/unmute</Tracking>
+          <Tracking event="pause">/wrapper/pause</Tracking>
+          <Tracking event="resume">/wrapper/resume</Tracking>
+          <Tracking event="fullscreen">/wrapper/fullscreen</Tracking>
+          <Tracking event="progress" offset="02:02:02">/wrapper/progabs</Tracking>
+          <Tracking event="progress" offset="20%">/wrapper/progrel</Tracking>
+        </TrackingEvents>
+        <VideoClicks>
+          <ClickTracking>/wrapper/click</ClickTracking>
+        </VideoClicks>
+      </Linear>
+    </Creative>
+    <Creative AdID="602833-NonLinearTracking">
+      <NonLinearAds>
+        <TrackingEvents>
+          <Tracking event="creativeView">/wrapper/nlcreativeView</Tracking>
+        </TrackingEvents>
+      </NonLinearAds>
+    </Creative>
+  </Creatives>
+  </Wrapper>
+  </Ad>
+</VAST>

--- a/test/assets/vast_wrapper_linear_2.xml
+++ b/test/assets/vast_wrapper_linear_2.xml
@@ -4,35 +4,35 @@
   <Wrapper>
     <AdSystem>Acudeo Compatible</AdSystem>
     <VASTAdTagURI>./test/assets/vast_wrapper_linear_1.xml</VASTAdTagURI>
-    <Error>/wrapper/error</Error>
-    <Impression>/wrapper/impression</Impression>
+    <Error>/wrapper2/error</Error>
+    <Impression>/wrapper2/impression</Impression>
   <Creatives>
     <Creative AdID="602833">
       <Linear>
         <TrackingEvents>
-          <Tracking event="creativeView">/wrapper/creativeView</Tracking>
-          <Tracking event="start">/wrapper/start</Tracking>
-          <Tracking event="midpoint">/wrapper/midpoint</Tracking>
-          <Tracking event="firstQuartile">/wrapper/firstQuartile</Tracking>
-          <Tracking event="thirdQuartile">/wrapper/thirdQuartile</Tracking>
-          <Tracking event="complete">/wrapper/complete</Tracking>
-          <Tracking event="mute">/wrapper/mute</Tracking>
-          <Tracking event="unmute">/wrapper/unmute</Tracking>
-          <Tracking event="pause">/wrapper/pause</Tracking>
-          <Tracking event="resume">/wrapper/resume</Tracking>
-          <Tracking event="fullscreen">/wrapper/fullscreen</Tracking>
-          <Tracking event="progress" offset="02:02:02">/wrapper/progabs</Tracking>
-          <Tracking event="progress" offset="20%">/wrapper/progrel</Tracking>
+          <Tracking event="creativeView">/wrapper2/creativeView</Tracking>
+          <Tracking event="start">/wrapper2/start</Tracking>
+          <Tracking event="midpoint">/wrapper2/midpoint</Tracking>
+          <Tracking event="firstQuartile">/wrapper2/firstQuartile</Tracking>
+          <Tracking event="thirdQuartile">/wrapper2/thirdQuartile</Tracking>
+          <Tracking event="complete">/wrapper2/complete</Tracking>
+          <Tracking event="mute">/wrapper2/mute</Tracking>
+          <Tracking event="unmute">/wrapper2/unmute</Tracking>
+          <Tracking event="pause">/wrapper2/pause</Tracking>
+          <Tracking event="resume">/wrapper2/resume</Tracking>
+          <Tracking event="fullscreen">/wrapper2/fullscreen</Tracking>
+          <Tracking event="progress" offset="02:02:02">/wrapper2/progabs</Tracking>
+          <Tracking event="progress" offset="20%">/wrapper2/progrel</Tracking>
         </TrackingEvents>
         <VideoClicks>
-          <ClickTracking>/wrapper/click</ClickTracking>
+          <ClickTracking>/wrapper2/click</ClickTracking>
         </VideoClicks>
       </Linear>
     </Creative>
     <Creative AdID="602833-NonLinearTracking">
       <NonLinearAds>
         <TrackingEvents>
-          <Tracking event="creativeView">/wrapper/nlcreativeView</Tracking>
+          <Tracking event="creativeView">/wrapper2/nlcreativeView</Tracking>
         </TrackingEvents>
       </NonLinearAds>
     </Creative>

--- a/test/test-wrapper-abort-limit-0.js
+++ b/test/test-wrapper-abort-limit-0.js
@@ -1,0 +1,24 @@
+var assert = buster.referee.assert;
+var refute = buster.referee.refute;
+
+buster.testCase("Single wrapped ad", {
+  prepare: function(done) {
+    var that = this;
+    VAST_VMAP_XHROptions.defaultVASTAbortLimit = 0
+    queryVAST("./test/assets/vast_wrapper_linear_1.xml", function () {}, function (e) {
+      that.e = e;
+      done();
+    });
+  },
+
+  "has error": function () {
+    refute.isNull(this.e)
+  },
+  "has correct error message": function () {
+    assert.equals(this.e.toString(), "Error: Reached abort limit of (" + 0 + ") wrappers.");
+  },
+  tearDown: function () {
+    VAST_VMAP_XHROptions.defaultVASTAbortLimit = -1
+  }
+
+})

--- a/test/test-wrapper-abort-limit.js
+++ b/test/test-wrapper-abort-limit.js
@@ -16,6 +16,9 @@ buster.testCase("Single wrapped ad", {
   },
   "has correct error message": function () {
     assert.equals(this.e.toString(), "Error: Reached abort limit of (" + 1 + ") wrappers.");
+  },
+  tearDown: function () {
+    VAST_VMAP_XHROptions.defaultVASTAbortLimit = -1
   }
 
 })

--- a/test/test-wrapper-abort-limit.js
+++ b/test/test-wrapper-abort-limit.js
@@ -1,0 +1,21 @@
+var assert = buster.referee.assert;
+var refute = buster.referee.refute;
+
+buster.testCase("Single wrapped ad", {
+  prepare: function(done) {
+    var that = this;
+    VAST_VMAP_XHROptions.defaultVASTAbortLimit = 1
+    queryVAST("./test/assets/vast_wrapper_linear_2.xml", function () {}, function (e) {
+      that.e = e;
+      done();
+    });
+  },
+
+  "has error": function () {
+    refute.isNull(this.e)
+  },
+  "has correct error message": function () {
+    assert.equals(this.e.toString(), "Error: Reached abort limit of (" + 1 + ") wrappers.");
+  }
+
+})

--- a/test/test-wrapper-no-abort-limit.js
+++ b/test/test-wrapper-no-abort-limit.js
@@ -1,0 +1,39 @@
+var assert = buster.referee.assert;
+var refute = buster.referee.refute;
+
+buster.testCase("Single wrapped ad", {
+  prepare: function(done) {
+    var that = this;
+    queryVAST("./test/assets/vast_wrapper_linear_2.xml", function(ads) {
+      that.vast = ads;
+      done();
+    });
+  },
+
+  setUp: function() {
+    this.ad = this.vast.getAd();
+    this.ad.sentImpression = false;
+  },
+
+  "has ad": function() {
+    refute.isNull(this.ad);
+  },
+
+  "finds linear": function() {
+    refute.isNull(this.ad.linear);
+  },
+
+  "finds linear click through": function() {
+    assert.equals(this.ad.linear.clickThrough, "http://linear.test.com");
+
+  },
+
+  "finds linear media files": function() {
+      assert.equals(this.ad.linear.mediaFiles.length, 4);
+  },
+
+  "finds linear media files": function() {
+      assert.equals(this.ad.linear.duration, 3661);
+  },
+
+})


### PR DESCRIPTION
Tried to avoid changing the existing API.  

A `VASTAd` object now gets a property `abortLimit` which is always -1 of it's `parentAd`, if it has one.  `queryVAST` fn will cancel the next `fetchXML` call when the `parentAd`'s `abortLimit` is zero (`0`) and immediately call the `onError` callback.  The default abort limit is set in `VAST_VMAP_XHROptions.defaultVASTAbortLimit`.   Setting this limit to `-1`, the default, implies that there is no limit, the current behavior.  Don't set to `0` as weirdness may occur.

++ Unit tests covering both cases -- 2 depth wrappers, with the limit set at -1, and 1, respectively.

